### PR TITLE
Bugfix/remove lock version

### DIFF
--- a/lib/naive_dice/bookings/ticket_schema.ex
+++ b/lib/naive_dice/bookings/ticket_schema.ex
@@ -23,6 +23,5 @@ defmodule NaiveDice.Bookings.TicketSchema do
     ticket_schema
     |> cast(attrs, [:event_id, :amount_pennies, :currency, :type, :available_tickets_count])
     |> validate_required([:event_id, :available_tickets_count])
-    |> optimistic_lock(:lock_version)
   end
 end

--- a/lib/naive_dice/bookings/ticket_schema.ex
+++ b/lib/naive_dice/bookings/ticket_schema.ex
@@ -10,7 +10,6 @@ defmodule NaiveDice.Bookings.TicketSchema do
     field :currency, :string
     field :type, :string
     field :available_tickets_count, :integer
-    field :lock_version, :integer, default: 1
 
     belongs_to :event, Event, foreign_key: :event_id
     has_many :tickets, Ticket

--- a/priv/repo/migrations/20181211225738_remove_lock_version_from_ticket_schemas_table.exs
+++ b/priv/repo/migrations/20181211225738_remove_lock_version_from_ticket_schemas_table.exs
@@ -1,0 +1,9 @@
+defmodule NaiveDice.Repo.Migrations.RemoveLockVersionFromTicketSchemasTable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:ticket_schemas) do
+      remove :lock_version
+    end
+  end
+end


### PR DESCRIPTION
After #2 is merge and there is no need for rollback we can remove the `lock_version` column